### PR TITLE
Added 'void end()' function to FirebaseData class (fixes a compilation issue with Arduino IDE)

### DIFF
--- a/src/Firebase_Arduino_WiFiNINA.cpp
+++ b/src/Firebase_Arduino_WiFiNINA.cpp
@@ -43,6 +43,8 @@
 #ifndef Firebase_Arduino_WiFiNINA_CPP
 #define Firebase_Arduino_WiFiNINA_CPP
 
+#include "Arduino.h"
+
 #include "Firebase_Arduino_WiFiNINA.h"
 
 struct Firebase_Arduino_WiFiNINA::FirebaseDataType

--- a/src/Firebase_Arduino_WiFiNINA.h
+++ b/src/Firebase_Arduino_WiFiNINA.h
@@ -43,7 +43,7 @@
 #ifndef Firebase_Arduino_WiFiNINA_H
 #define Firebase_Arduino_WiFiNINA_H
 
-#include <Arduino.h>
+#include "Arduino.h"
 
 #include "Firebase_Arduino_WiFiNINA_HTTPClient.h"
 
@@ -783,6 +783,10 @@ class FirebaseData
 
         @return - Boolean type status indicates the success of operation.
 
+    */
+    void end();
+    /*
+        Release memory used by FirebaseData object
     */
     bool pauseFirebase(bool pause);
 


### PR DESCRIPTION
On compiling in Arduino IDE an error would be thrown for Firebase_Arduino_WiFiNINA.cpp lines 1552 and 1555 stating end() is not specified in this scope. To fix this issue I added the function void end() to the FirebaseData class in Firebase_Arduino_WiFiNINA.h.